### PR TITLE
Use Multi-file output from clang-tidy

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,7 @@ class ClangTidy(Linter):
 
     executable = 'clang-tidy'
     regex = (
-        r'(^.+?:(?P<line>\d+):(?P<col>\d+): )?'
+        r'(^(?P<filename>.+?):(?P<line>\d+):(?P<col>\d+): )?'
         r'(?:(?P<error>error)|(?P<warning>warning)): '
         r'(?P<message>.+)'
     )
@@ -77,12 +77,11 @@ class ClangTidy(Linter):
 
     def split_match(self, match):
         """Return the components of the error message."""
-        match, line, col, error, warning, message, near = \
-            super().split_match(match)
+        lint_match = super().split_match(match)
 
         # if the line could not be extracted from the output we set it to the
         # first line to show the message in the error pane
-        if line is None:
-            line = 0
+        if lint_match.line is None:
+            lint_match.line = 0
 
-        return match, line, col, error, warning, message, near
+        return lint_match


### PR DESCRIPTION
Sublime-linter got support for messages from multiple files by @mheinzler.
This PR adds the ?P<filename> to the regex.

I have to remove the split_match function, because it did not handle the filename.
