### PR TITLE
Implement compile_commands as a linter setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ following entry to your `.sublime-project`**:
     "settings":
     {
         // ...
-        "compile_commands": "${project_path}/PATH/TO/YOUR/BUILD/DIR"
+        "SublimeLinter.linters.clangtidy.compile_commands": "${project_path}/PATH/TO/YOUR/BUILD/DIR"
         // ...
     }
 }

--- a/linter.py
+++ b/linter.py
@@ -36,12 +36,19 @@ class ClangTidy(Linter):
 
     def cmd(self):
         """Return the actual command to invoke."""
-        settings = self.view.settings()
-        compile_commands = settings.get("compile_commands", "")
+
+        # check the linter settings for the path to the compile_commands file
+        settings = self.get_view_settings()
+        compile_commands = settings.get("compile_commands")
+        if not compile_commands:
+            # for backwards compatibility check the view settings directly
+            settings = self.view.settings()
+            compile_commands = settings.get("compile_commands", "")
+
         if not compile_commands:
             self.notify_failure()
-            logger.info('No "compile_commands" key present in the settings '
-                        'of the view.')
+            logger.info('No "compile_commands" key present in the linter '
+                        'settings. Please check your project settings.')
             return [self.executable, "-version"]
         vars = self.view.window().extract_variables()
         compile_commands = sublime.expand_variables(compile_commands, vars)


### PR DESCRIPTION
This turns the `compile_commands` setting into an actual linter setting, which makes more sense to me because it is clearer and also for consistency with other linters. 

@rwols Are you OK with such a change?

Fixes #3 