### PR TITLE
Remove the config argument to avoid overwriting the configuration file

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -55,7 +55,6 @@ class ClangTidy(Linter):
             return ["clang-tidy",
                     "-quiet",
                     "-p={}".format(compile_commands),
-                    "-config=",
                     "${args}",
                     "$file"]
         else:


### PR DESCRIPTION
In newer versions of clang-tidy it seems that this option disables the configuration file and needs to be removed. At least that is the case for me, but unfortunately I can't test with older versions at the moment.

@rwols Do you know why this argument was added? I'm not sure if this would break the plugin for users with older versions of clang-tidy (<=10?).